### PR TITLE
Update ApiErrorHandler.php

### DIFF
--- a/src/Traits/ApiErrorHandler.php
+++ b/src/Traits/ApiErrorHandler.php
@@ -15,6 +15,9 @@ trait ApiErrorHandler
         $handler = new $class($exception);
         $handler->handleStatusCode();
         $handler->handleMessage();
-        return Response::json(["error"=>$handler->getMessage()],$handler->getStatusCode(),["Content-Type"=>"application/json"]);
+        return Response::json([
+                               "success" => false,
+                               "error"=>$handler->getMessage()
+                              ],$handler->getStatusCode(),["Content-Type"=>"application/json"]);
     }
 }


### PR DESCRIPTION
So many frontend developers count on response keywords to determine if the response is really responded to by the end of the backend code or not. cause response may failed at the middle of its way