### PR TITLE
Fix ValidationExceptionHandler.php

### DIFF
--- a/src/Handlers/ValidationExceptionHandler.php
+++ b/src/Handlers/ValidationExceptionHandler.php
@@ -11,7 +11,7 @@ class ValidationExceptionHandler extends ExceptionHandler
 
     protected function setMessage(): void
     {
-        $this->message = $this->exception->errors();
+        $this->message = $this->exception->getMessage();
     }
 
     protected function setData(): void


### PR DESCRIPTION
message needs to be a string, fixes 
`TypeError: Cannot assign array to property hamidreza2005\LaravelApiErrorHandler\Handlers\ExceptionHandler::$message of type string in /var/www/html/vendor/hamidreza2005/laravel-api-error-handler/src/Handlers/ValidationExceptionHandler.php:14`